### PR TITLE
POC: 'sidepath_estimation' and 'proc_is_sidepath_poc'

### DIFF
--- a/processing/constants/topics.const.ts
+++ b/processing/constants/topics.const.ts
@@ -15,6 +15,8 @@ const bboxBerlin: TopicConfigBbox = [13.08283, 52.33446, 13.762245, 52.6783]
 const bboxBiBi: TopicConfigBbox = [9.0671, 48.9229, 9.1753, 48.9838]
 
 const config = [
+  ['sidepath_estimation', null],
+  ['proc_is_sidepath_poc', null],
   ['roads_bikelanes', null],
   ['bikeroutes', null],
   ['bicycleParking', null],

--- a/processing/custom_functions/sidepath_lib.sql
+++ b/processing/custom_functions/sidepath_lib.sql
@@ -1,0 +1,287 @@
+-------------------------------------------
+-- helper functions for sidepath estimation
+--
+-- Prerequisites:
+-- -------------
+-- 
+-- Two tables are required for sidepath estimation:
+--
+-- 1. _sidepath_estimation_paths(id bigint, geom linestring, tags jsonb):
+--    A table of geometries and tags that should be considered "paths"
+--   (i.e., ways for which we want to estimate `is_sidepath`)
+--    
+--    The `tags` object is expected to be of the format returned by
+--    `topics/helper/ExtractPublicTags(object)`, where `object` is the
+--    what gets passed into `osm2pgsql.process_way()`.
+-- 
+-- 2. _sidepath_estimation_roads(id bigint, geom linestring, tags jsonb):
+--    A table of geometries and tags that should be considered as "roads".
+--   (i.e., ways which we assume they might have sidepaths)
+--    Columns have the same types as in _sidepath_estimation_paths.
+--
+-- Provided functions:
+-- -------------------
+-- 
+-- - sidepath_idlist_yes(buffer_distance, buffer_size):
+--   Lists the id's for which estimated `is_sidepath` is 'yes'
+-- 
+-- - sidepath_idlist_no(buffer_distance, buffer_size):
+--   Lists the id's for which estimated `is_sidepath` is 'no'
+-- 
+-- - sidepath_dict_jsonl(buffer_distance, buffer_size):
+--   Lists 2-element json arrays of the format: [id, sidepath_dict_entry], where
+--   - id: osm id
+--   - sidepath_dict_entry: {
+--       checks: number,
+--       id: { [index: number]: number },
+--       name: { [index: string]: number },
+--       highway: { [index: string]: number },
+--       maxspeed: { [index: string]: number }
+--     }
+--   (Note that this is an intermediate result...
+--    the sidepath_idlist_* functions are probably enough and also quicker)
+--     
+--
+
+-- create temporary paths and roads table if required; otherwise we cannot define some functions below
+CREATE TEMP TABLE IF NOT EXISTS  _sidepath_estimation_paths(id bigint, geom geometry, tags jsonb);
+CREATE TEMP TABLE IF NOT EXISTS  _sidepath_estimation_roads(id bigint, geom geometry, tags jsonb);
+
+CREATE SEQUENCE IF NOT EXISTS checkpoint_nr_sequence;
+
+CREATE OR REPLACE FUNCTION text_empty_if_null(t text) RETURNS text AS $$
+  SELECT CASE WHEN t IS NULL THEN '' ELSE t END
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION text_both_null_or_eq(v1 text, v2 text) RETURNS boolean AS $$
+  SELECT (v1 IS NULL AND v2 IS NULL) OR v1 = v2
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION jsonb_get_or_default(o jsonb, k text, df jsonb) RETURNS jsonb AS $$
+  SELECT CASE WHEN o ? k THEN o -> k ELSE df END
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION jsonb_intset_add(o jsonb, n bigint) RETURNS jsonb AS $$
+  SELECT jsonb_set(o, ARRAY[n::text], 'true'::jsonb) 
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_dict_add_entry(o jsonb, k text, buffer_id bigint) RETURNS jsonb AS $$
+  SELECT CASE WHEN k is NULL
+    THEN
+      o
+    ELSE
+      jsonb_set(o, ARRAY[k], jsonb_intset_add(jsonb_get_or_default(o, k, '{}'::jsonb), buffer_id))
+    END
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION integer_inc_not_visited(visited jsonb, t text, n integer) RETURNS integer AS $$
+  SELECT CASE WHEN visited ? t THEN n ELSE n + 1 END
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_dict_inc_field(o jsonb, visited jsonb, field text, buffer_id bigint) RETURNS jsonb AS $$
+  SELECT CASE WHEN field IS NULL
+    THEN
+      o
+    ELSE
+      jsonb_set(o, ARRAY[field], to_jsonb(integer_inc_not_visited(visited -> field, buffer_id::text, jsonb_get_or_default(o, field, '0'::jsonb)::integer)))
+    END
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_dict_valid_speed(v text) RETURNS boolean AS $$
+  SELECT v IS NOT NULL AND v ~ '^[0-9][0-9.]*$' 
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_dict_max_field(o jsonb, field text, value text) RETURNS jsonb AS $$
+  SELECT CASE WHEN field IS NOT NULL AND sidepath_dict_valid_speed(value)
+    THEN
+      jsonb_set(o, ARRAY[field], to_jsonb(GREATEST(jsonb_get_or_default(o, field, to_jsonb(value::integer))::integer, value::integer)))
+    ELSE
+      o
+    END
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_dict_add_result(result jsonb, visited jsonb, buffer_id bigint, buffer_layer text, road_id bigint, tags jsonb) RETURNS jsonb AS $$
+  SELECT
+    jsonb_set(
+      result,
+      ARRAY['checks'], to_jsonb(integer_inc_not_visited(visited -> 'nrs', buffer_id::text, (result -> 'checks')::integer))
+    ) || CASE WHEN text_both_null_or_eq(buffer_layer, tags ->> 'layer')
+         THEN
+           jsonb_build_object(
+             'id', sidepath_dict_inc_field(result -> 'id', visited -> 'road_ids', road_id::text, buffer_id),
+             'highway', sidepath_dict_inc_field(result -> 'highway', visited -> 'highways', tags ->> 'highway', buffer_id),
+             'name', sidepath_dict_inc_field(result -> 'name', visited -> 'names', text_empty_if_null(tags ->> 'name'), buffer_id),
+             'maxspeed', sidepath_dict_max_field(result -> 'maxspeed', tags ->> 'highway', (tags ->> 'maxspeed'))
+           )
+         ELSE
+           '{}'::jsonb
+         END
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION  sidepath_dict_add_visited(visited jsonb, buffer_id bigint, buffer_layer text, road_id bigint, tags jsonb) RETURNS jsonb AS $$
+  SELECT
+    jsonb_set(
+      visited,
+      ARRAY['nrs'], jsonb_intset_add(visited -> 'nrs', buffer_id) 
+    ) || CASE WHEN text_both_null_or_eq(buffer_layer, tags ->> 'layer')
+         THEN
+           jsonb_build_object(
+                 'road_ids', sidepath_dict_add_entry(visited -> 'road_ids', road_id::text, buffer_id),
+                 'highways', sidepath_dict_add_entry(visited -> 'highways', tags ->> 'highway', buffer_id),
+                 'names', sidepath_dict_add_entry(visited -> 'names', text_empty_if_null(tags ->> 'name'), buffer_id)
+            )
+         ELSE
+           '{}'::jsonb
+         END
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_dict_acc_init_if_null(acc jsonb) RETURNS jsonb AS $$
+  SELECT CASE WHEN acc IS NULL
+    THEN '{
+      "visited": { "nrs": {}, "road_ids": {}, "highways": {}, "names": {} },
+      "result": { "checks": 0, "id": {}, "highway": {}, "name": {}, "maxspeed": {} }
+      }'::jsonb
+    ELSE
+      acc
+    END
+$$ LANGUAGE SQL;
+
+-- TODO: fix this version
+CREATE OR REPLACE FUNCTION sidepath_dict_acc_without_nulls(acc jsonb, buffer_id bigint, buffer_layer text, road_id bigint, tags jsonb) RETURNS jsonb AS $$
+  SELECT CASE WHEN tags IS NOT NULL 
+    THEN
+     jsonb_build_object(
+      'visited', sidepath_dict_add_visited(sidepath_dict_acc_init_if_null(acc) -> 'visited', buffer_id, buffer_layer, road_id, tags),
+      'result', sidepath_dict_add_result(sidepath_dict_acc_init_if_null(acc) -> 'result', acc -> 'visited', buffer_id, buffer_layer, road_id, tags)
+      )
+    ELSE
+      acc
+    END
+$$ LANGUAGE SQL;
+
+
+CREATE OR REPLACE FUNCTION sidepath_dict_acc(acc jsonb, buffer_id bigint, buffer_layer text, road_id bigint, tags jsonb) RETURNS jsonb AS $$
+  SELECT   jsonb_build_object(
+      'visited', sidepath_dict_add_visited(acc -> 'visited', buffer_id, buffer_layer, road_id, tags),
+      'result', sidepath_dict_add_result(acc -> 'result', acc -> 'visited', buffer_id, buffer_layer, road_id, tags)
+      )
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_dict_get_result(acc jsonb) RETURNS jsonb AS $$
+  SELECT acc -> 'result'
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE AGGREGATE sidepath_dict_agg(buffer_id bigint, buffer_layer text, road_id bigint, tags jsonb) (
+  sfunc = sidepath_dict_acc,
+  stype = jsonb,
+  finalfunc = sidepath_dict_get_result,
+  initcond =  '{
+      "visited": { "nrs": {}, "road_ids": {}, "highways": {}, "names": {} },
+      "result": { "checks": 0, "id": {}, "highway": {}, "name": {}, "maxspeed": {} }
+      }');
+
+CREATE OR REPLACE FUNCTION sidepath_dict_interpolated_points(point_distance float, geom geometry) RETURNS setof geometry AS $$
+  SELECT (
+      ST_Dump(
+        ST_Union(
+          CASE
+            WHEN ST_Length(geom) >= point_distance THEN ARRAY [
+                                                ST_Startpoint(geom), 
+                                                ST_Endpoint(geom), 
+                                                ST_Lineinterpolatepoints(geom, point_distance/st_length(geom))
+                                            ]
+            ELSE ARRAY [
+                                                ST_Startpoint(geom), 
+                                                ST_Endpoint(geom)
+                                            ]
+          END
+        )
+      )
+    ).geom
+$$ LANGUAGE SQL;
+
+
+CREATE OR REPLACE FUNCTION sidepath_dict_is_sidepath_by_checks(checks int, histogram jsonb) RETURNS boolean AS $$
+  SELECT EXISTS (
+    SELECT value FROM jsonb_each(histogram)
+    WHERE (checks <= 2 AND value::int = checks)
+    OR    checks::float * 0.66 <= value::float
+  )
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_dict_is_sidepath(entry jsonb) RETURNS boolean AS $$
+  SELECT
+    sidepath_dict_is_sidepath_by_checks((entry -> 'checks')::int, entry -> 'id')
+    OR sidepath_dict_is_sidepath_by_checks((entry -> 'checks')::int, entry -> 'highway')
+    OR sidepath_dict_is_sidepath_by_checks((entry -> 'checks')::int, entry -> 'name')
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_dict_format_jsonl(id bigint, sidepath_dict_entry jsonb) RETURNS jsonb as $$
+  SELECT json_array(id, sidepath_dict_entry)
+$$ LANGUAGE SQL;
+
+
+CREATE OR REPLACE FUNCTION sidepath_dict_checkpoints_and_roads_left_outer_join(buffer_distance float, buffer_size float)
+  RETURNS TABLE (id bigint, nr bigint, layer text, road_id bigint, tags jsonb) AS $$
+  WITH points AS (
+    SELECT
+      id,
+      nextval('checkpoint_nr_sequence') AS nr,
+      tags -> 'tags' ->> 'layer' as layer,
+      (sidepath_dict_interpolated_points($1, geom)) AS geom
+    FROM
+      _sidepath_estimation_paths
+    ORDER BY
+      id
+  )
+  SELECT
+    points.id, points.nr, points.layer, roads.id, roads.tags -> 'tags'
+  FROM
+    points
+    LEFT OUTER JOIN _sidepath_estimation_roads AS roads ON ST_DWithin(points.geom, roads.geom, $2)
+  ORDER BY
+    points.id
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_dict_checkpoints_and_roads_join(buffer_distance float, buffer_size float)
+  RETURNS TABLE (id bigint, nr bigint, layer text, road_id bigint, tags jsonb) AS $$
+  WITH points AS (
+    SELECT
+      id,
+      nextval('checkpoint_nr_sequence') AS nr,
+      tags -> 'tags' ->> 'layer' as layer,
+      (sidepath_dict_interpolated_points($1, geom)) AS geom
+    FROM
+      _sidepath_estimation_paths
+    ORDER BY
+      id
+  )
+  SELECT
+    points.id, points.nr, points.layer, roads.id, roads.tags -> 'tags'
+  FROM
+    points
+    JOIN _sidepath_estimation_roads AS roads ON ST_DWithin(points.geom, roads.geom, $2)
+  ORDER BY
+    points.id
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_dict_jsonl(buffer_distance float, buffer_size float) RETURNS TABLE (json_line text) AS $$
+  SELECT sidepath_dict_format_jsonl(id, sidepath_dict_agg(nr, layer, road_id, tags)) FROM sidepath_dict_checkpoints_and_roads_left_outer_join(buffer_distance, buffer_size)
+  GROUP BY id;
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_idlist_yes(buffer_distance float, buffer_size float) RETURNS TABLE (id bigint) AS $$
+  SELECT id FROM (
+    SELECT id, sidepath_dict_agg(nr, layer, road_id, tags) AS entry FROM sidepath_dict_checkpoints_and_roads_join(buffer_distance, buffer_size)
+    GROUP BY id
+  )
+  WHERE sidepath_dict_is_sidepath(entry);
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE FUNCTION sidepath_idlist_no(buffer_distance float, buffer_size float) RETURNS TABLE (id bigint) AS $$
+  SELECT id FROM (
+    SELECT id, sidepath_dict_agg(nr, layer, road_id, tags) AS entry FROM sidepath_dict_checkpoints_and_roads_left_outer_join(buffer_distance, buffer_size)
+    GROUP BY id
+  )
+  WHERE entry IS NULL OR NOT sidepath_dict_is_sidepath(entry);
+$$ LANGUAGE SQL;

--- a/processing/topics/proc_is_sidepath_poc/proc_is_sidepath_poc.lua
+++ b/processing/topics/proc_is_sidepath_poc/proc_is_sidepath_poc.lua
@@ -1,0 +1,50 @@
+package.path = package.path .. ";/processing/topics/helper/?.lua"
+local dir = ";/processing/topics/proc_is_sidepath_poc/"
+package.path = package.path .. dir .. "sidepath/?.lua"
+
+require('HighwayClasses')
+require('Sidepath')
+require('DefaultId')
+require('ExtractPublicTags')
+require('Metadata')
+
+local is_sidepath_set = IsSidepathSet('/data/hashes/is_sidepath.idlines.txt')
+
+local paths_table = osm2pgsql.define_table({
+  name = 'with_proc_is_sidepath',
+  ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+  columns = {
+    { column = 'id',      type = 'text'  },
+    { column = 'tags',    type = 'jsonb' },
+    { column = 'meta',    type = 'jsonb' },
+    { column = 'geom',    type = 'linestring' },
+    { column = 'minzoom', type = 'integer' },
+  },
+  indexes = {
+    { column = 'geom', method = 'gist' },
+    { column = 'id',   method = 'btree', unique = true }
+  }
+})
+
+
+function osm2pgsql.process_way(object)
+  -- SidpathDict.get will only load the dict once
+  local tags = object.tags
+  local id =  tonumber(object.id)
+
+  local s = is_sidepath_set:get()
+  if PathClasses[tags.highway] and s[id] then
+    tags.proc_is_sidepath = 'yes'
+  else
+    tags.proc_is_sidepath = 'no'
+  end
+  if PathClasses[tags.highway] then
+    paths_table:insert({
+      id = DefaultId(object),
+      tags = ExtractPublicTags(object),
+      meta = Metadata(object),
+      geom = object:as_linestring(),
+    })
+  end
+
+end

--- a/processing/topics/proc_is_sidepath_poc/sidepath/Sidepath.lua
+++ b/processing/topics/proc_is_sidepath_poc/sidepath/Sidepath.lua
@@ -1,0 +1,42 @@
+-- TODO: the json lib should be stored in "helpers" or installed with luarocks, probably
+local inspect = require('inspect')
+
+-- TODO: annotate with type annotations
+local function read_sidepath_set(path)
+  print('TODO: start reading is_sidepath_set')
+  local start = os.time()
+  local linecount = 0
+  local result = {}
+  for l in io.lines(path) do
+    linecount = linecount + 1
+    local osm_id = tonumber(l)
+    if osm_id == nil then
+      print('ERROR: cannot parse key for line:', inspect(l))
+      return
+    end
+    if result[osm_id] == nil then
+      result[osm_id] = true
+      else
+        print('ERROR: duplicate entry', osm_id)
+      end
+  end
+  print('TODO: done reading sidepath_dict in', os.difftime(os.time(), start), 's')
+  print('  ids in is_sidpath_set: ', linecount)
+  return result
+end
+
+---comment
+---@param path string
+---@return table
+function IsSidepathSet(path)
+  local sidepath_dict = nil
+  return {
+    get = function(self)
+      if sidepath_dict == nil then
+        sidepath_dict = read_sidepath_set(path)
+      end
+      return sidepath_dict
+    end
+  }
+end
+

--- a/processing/topics/sidepath_estimation/relevant_ways/IsSidepathRelevant.lua
+++ b/processing/topics/sidepath_estimation/relevant_ways/IsSidepathRelevant.lua
@@ -1,0 +1,77 @@
+require("Set")
+
+local function bicycle_ok(tags) return tags.bicycle == 'yes' or tags.bicycle == 'designated' or tags.bicycle  == 'permissive' end
+
+---Test the tags of a way should be included in sidepath estimation.
+---The rules are taken from the original Cycling-Quality-Index implementation:
+---- https://github.com/SupaplexOSM/OSM-Cycling-Quality-Index?tab=readme-ov-file#how-to-use-this-script
+---@return boolean
+function IsSidepathRelevant(tags)
+
+  -- This should be equivalent to the original overpass-query linked in CQI-repo:
+  --   https://overpass-turbo.eu/?q=W291dDpqc29uXQpbYmJveDo1Mi40NTQzMjQ2MDA5MTEwNzg4LDEzLjM5xJgzNDfEmcSsNTDElzYsxJEuxLDEnDE5xLfEncSgMMSZxKTEpjQ4NTnEoTJdOwovL8SLxI3Ej3t7xIzEjn19xYgKKAogIHdheVsiaGlnaMWceSI9ImN5Y2xlxaUixZbFmsWlxZ_FocWjxa_FqHBhdGjFsMWfYmnFqsWsZSIhxahub8W9IsW_xoHFrcaExahkaXNtxIFudMWwxYnFssWdxbTFosWkxZ3FpyJmb290xa9dxb7GgMWrxo3FqHllc8aXxZnFm8aaxaDGnMW3xqDGosakxp7GpsaKxqjGgsafZMatxaJuxbplZMavxpnFnsazxbbGnsWoxqHGo8alxqfGjMaDxbhlcm3GkXNpdsaDxbHGsceIxbXGncWmxahicmlkxa3Hj8a7x5HGn8asxq7HnMWzx4nHoMafx6PHpcenxrnHkMapx5Iixr_HmGfHgnTHhMeGx53Gm8eKx6HGisekx6bFrse2x6nHuMafcMeUx5Zzx5jHmsiBx6_Hn8a1c8e_cMetx7fGvcarxq3IlMayyJbHiyLImGXImsaJxovIjMaPx4DHvceDx4XHrsihxrTIo8ilyKfGusipyJ0iyI7HlceXx5nHm8WJxrDIlciyyIXGk3RvcsalxpjIgsewxrXJhMmGxaVfbGlua8igx57JgsafdHJ1yZPJlciDx7HFqMmZyZtryZDJksmUxZbJgMixyITIjcekbWFyxabIsMmWyarFuMmsya55yaTJnMmxyZ7Il2VjxIdkybbJncmLyLPJvcm_ybbJuMmmyYnJgcmzIse_cnRpyoHJusqDyIXKjsqQyofJkcm5yorJqcmfIsmbxaxhyJFpZmnIgMqTyKLIhXLHgMa_xpXKkWzKgsqoxp_JkXbJkmdfyJjKqmXGlsqnyZfHk8e7yZnKkW7KsMq9InJvYcivyL_Hh8m7yoRyyrRjx5tbIcikx5TLj8i-yajJssqdc8uVxoDLkcuUy47LncafYWzFrcmwypvLmcm8y6DLkMioxrzGqiLHrMuDyozLm8uqy57It8uux7vHgciuy7HLmsucy6vItsutx7nIusiQyJLLl8uLypTJmHJhY8qJCinFicWLIHDHpMaVIMqqc3VsdHMKxIF0IMSNZHnFiT7FicydIHNrZWwgcXQ7&c=BPKl81fY-P---@param tags table
+  return (
+ --  way["highway"="path"]["bicycle"!="no"]["bicycle"!="dismount"];
+    (tags.highway == 'path' and tags.bicycle ~= 'no' and tags.bicycle ~= 'dismount') or
+ --  way["highway"="footway"]["bicycle"="yes"];
+ --  way["highway"="footway"]["bicycle"="designated"];
+ --  way["highway"="footway"]["bicycle"="permissive"];
+    (tags.highway == 'footway' and bicycle_ok(tags)) or
+ --  way["highway"="bridleway"]["bicycle"="yes"];
+ --  way["highway"="bridleway"]["bicycle"="designated"];
+ --  way["highway"="bridleway"]["bicycle"="permissive"];
+    (tags.highway == 'bridleway' and bicycle_ok(tags)) or
+ --  way["highway"="steps"]["bicycle"="yes"];
+ --  way["highway"="steps"]["bicycle"="designated"];
+ --  way["highway"="steps"]["bicycle"="permissive"];
+    (tags.highway == 'steps' and bicycle_ok(tags)) or
+ -- way["highway"="cycleway"];
+ --  way["highway"="motorway"];
+ --  way["highway"="motorway_link"];
+ --  way["highway"="trunk"];
+ --  way["highway"="trunk_link"];
+ --  way["highway"="primary"];
+ --  way["highway"="primary_link"];
+ --  way["highway"="secondary"];
+ --  way["highway"="secondary_link"];
+ --  way["highway"="tertiary"];
+ --  way["highway"="tertiary_link"];
+ --  way["highway"="unclassified"];
+ --  way["highway"="residential"];
+ --  way["highway"="living_street"];
+ --  way["highway"="pedestrian"];
+ --  way["highway"="road"];
+--  way["highway"="track"];
+    Set({
+      "cycleway",
+      "motorway",
+      "motorway_link",
+      "trunk",
+      "trunk_link",
+      "primary",
+      "primary_link",
+      "secondary",
+      "secondary_link",
+      "tertiary",
+      "tertiary_link",
+      "unclassified",
+      "residential",
+      "living_street",
+      "pedestrian",
+      "road",
+      "track",
+    })[tags.highway] or
+ --  way["highway"="service"][!"service"];
+ --  way["highway"="service"]["service"="alley"];
+    (tags.highway == 'service' and (tags.service == nil or tags.service == 'alley')) or
+ --  way["highway"="service"]["bicycle"="yes"];
+ --  way["highway"="service"]["bicycle"="designated"];
+ --  way["highway"="service"]["bicycle"="permissive"];
+    (tags.highway == 'service' and bicycle_ok(tags))
+  )
+end
+
+
+
+
+

--- a/processing/topics/sidepath_estimation/sidepath_estimation.lua
+++ b/processing/topics/sidepath_estimation/sidepath_estimation.lua
@@ -1,0 +1,78 @@
+package.path = package.path .. ";/processing/topics/helper/?.lua"
+package.path = package.path .. ";/processing/topics/sidepath_estimation/relevant_ways/?.lua"
+
+require("Set")
+require("JoinSets")
+require("Metadata")
+require("MergeTable")
+require("HighwayClasses")
+require("ExtractPublicTags")
+require("Round")
+require("DefaultId")
+require("IsSidepathRelevant")
+
+local roadsTable = osm2pgsql.define_table({
+  name = '_sidepath_estimation_roads',
+  ids = { type = 'any', id_column = 'id', type_column = 'osm_type' },
+  columns = {
+    { column = 'tags',    type = 'jsonb' },
+    { column = 'geom',    type = 'linestring' },
+  },
+  indexes = {
+    { column = 'geom', method = 'gist' },
+    { column = 'id',   method = 'btree', unique = true }
+  }
+})
+
+
+local pathsTable = osm2pgsql.define_table({
+  name = '_sidepath_estimation_paths',
+  ids = { type = 'any', id_column = 'id', type_column = 'osm_type' },
+  columns = {
+    { column = 'tags',    type = 'jsonb' },
+    { column = 'geom',    type = 'linestring' },
+    { column = 'minzoom', type = 'integer' },
+  },
+  indexes = {
+    { column = 'geom', method = 'gist' },
+    { column = 'id',   method = 'btree', unique = true }
+  }
+})
+
+
+function osm2pgsql.process_way(object)
+
+  local road_highway_classes = JoinSets({
+    HighwayClasses,
+    MajorRoadClasses,
+    MinorRoadClasses
+  })
+  local path_highway_classes = PathClasses
+  
+  local tags = object.tags
+
+  -- ====== (A) Filter-Guards ======
+  if not tags.highway then return end
+
+  -- Skip ways that are not relevant for sidepath estimation
+  if not IsSidepathRelevant(tags) then return end
+   
+  -- Skip any area. See https://github.com/FixMyBerlin/private-issues/issues/1038 for more.
+  if tags.area == 'yes' then return end
+
+
+  -- ====== (B) Compute results and insert ======
+
+  local publicTags = ExtractPublicTags(object)
+
+  local insert_table = {
+    tags = publicTags,
+    geom = object:as_linestring(),
+  }
+
+  if road_highway_classes[object.tags.highway] then
+    roadsTable:insert(insert_table)
+  elseif path_highway_classes[object.tags.highway] then
+    pathsTable:insert(insert_table)
+  end
+end

--- a/processing/topics/sidepath_estimation/sidepath_estimation.lua
+++ b/processing/topics/sidepath_estimation/sidepath_estimation.lua
@@ -55,7 +55,7 @@ function osm2pgsql.process_way(object)
   if not tags.highway then return end
 
   -- Skip ways that are not relevant for sidepath estimation
-  if not IsSidepathRelevant(tags) then return end
+  -- if not IsSidepathRelevant(tags) then return end
    
   -- Skip any area. See https://github.com/FixMyBerlin/private-issues/issues/1038 for more.
   if tags.area == 'yes' then return end

--- a/processing/topics/sidepath_estimation/sidepath_estimation.sql
+++ b/processing/topics/sidepath_estimation/sidepath_estimation.sql
@@ -1,0 +1,26 @@
+\set QUIET on
+\set ON_ERROR_STOP on
+
+-- set parameter defaults
+\set buffer_size 22.0
+\set buffer_distance 100.0
+\set outfile /data/hashes/is_sidepath.idlines.txt
+   
+-- reset sequence for checkpoint numbering
+\o /dev/null
+SELECT setval('checkpoint_nr_sequence', 1);
+
+-- set output to the result file
+\o :outfile
+
+\echo `date` 'Start generating is_sidepath ids'
+
+-- set appropiate formatting 
+\pset format unaligned
+\pset tuples_only on
+
+-- run the query
+SELECT * FROM sidepath_idlist_yes(:buffer_distance, :buffer_size);
+
+\echo `date` 'Done writing is_sidepath ids to:' :outfile
+

--- a/processing/utils/initializeCustomFunctions.ts
+++ b/processing/utils/initializeCustomFunctions.ts
@@ -3,5 +3,6 @@ import { $ } from 'bun'
 export async function initializeCustomFunctions() {
   await $`psql -q -f ./custom_functions/jsonb_diff.sql`
   await $`psql -q -f ./custom_functions/copy_mapillary_coverage_tags.sql`
+  await $`psql -q -f ./custom_functions/sidepath_lib.sql`
   return true
 }


### PR DESCRIPTION
Hi @tordans,

Das hier ist ein Proof-of-Concept für die sidepath estimation, die ohne Änderungen an der aktuellen processing-Struktur funktionieren sollte. 

- das Topic `sidepath_estimation` erstellt eine List von ids für die wir `is_sidepath=yes` schätzen
- das Topic `proc_is_sidepath_poc` benutzt die Liste exemplarisch um ein `proc_is_sidepath` tag zu "path-ways" hinzuzufügen
- die SQL-Funktionen für die sidepath estimation sind in `custom_functions/sidepath_lib.sql` definiert

Ich habe unten noch die Stellen kommentiert, die Du ggf anpassen möchtest.

Noch die Antworten auf die Fragen in Deiner Mail vom 25. Juni:

> _sidepath_estimation_roads, _sidepath_estimation_pathes ablege. Wir brauchen dort dann nur die Geometry + name + highway=*, richtig?

Es bräuchte auch noch `maxspeed` und `layer`. Aktuell funktionieren die SQL-Funktionen aber direkt auf dem `tags` json-Objekt. Können wir ggf aber anpassen. (EDIT: `maxspeed` könnte man auch weglassen, wenn es nur um die sidepath estimation gehen soll, merke ich gerade... das ist CQI-spezifisch)

> Die function schreibt dann in _sidepath_estimation_results (Spalten: osm_id=bigint, is_sidepath=true)
> 
> Der einfachste Weg ist dann, wenn ich ein off-by-one-day Setup mache und in der Initialisierung die diese Daten in ein CSV schreibe und das dann auslese und verwende. Ich habe dann 2 Lese-Vorgänge und 2-Array-Map-Lookups.

`psql` kann auch direkt in Dateien schreiben, siehe `topics/sidepath_estimation/sidepath_estimation.sql`. Dann braucht man kein off-by-one-day Setup, würde ich sagen.

Schreib' Deine Kommentare und weiteren Fragen gerne hier rein.

Viele Grüße und schönen Woche,

Lu
